### PR TITLE
Create a workflow for experimental SDKs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,6 @@
 name: Release
 env:
-  SDK_VERSION: 6.0.0
+  SDK_VERSION: 6.1.0
 on:
   push:
     branches: [main]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,6 @@
 name: Release
+env:
+  SDK_VERSION: 6.0.0
 on:
   push:
     branches: [main]
@@ -16,7 +18,15 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Publish
+      - name: Publish Stable
         uses: JS-DevTools/npm-publish@v1
+        if: ${{!contains(env.SDK_VERSION, 'beta')}}
         with:
           token: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish Experimental
+        uses: JS-DevTools/npm-publish@v1
+        if: ${{contains(env.SDK_VERSION, 'beta')}}
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          tag: next

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cohere-ai",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "A Node.js SDK with TypeScript support for the Cohere API.",
   "homepage": "https://docs.cohere.ai",
   "main": "index.js",


### PR DESCRIPTION
Added a runner for the current workflow to release the SDK version under the "next" tag so users won't download experimental SDK versions by default.

I tested this out locally by creating my own package: https://www.npmjs.com/package/will3838_package?activeTab=versions

If you try npm installing that package, you'll get the version tagged with latest rather than the one tagged with next event though it was the one most recently released.

Closes OS-365