### PR TITLE
🌿 introduce `chatStream` method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cohere-ai",
-    "version": "7.0.0",
+    "version": "7.1.0",
     "private": false,
     "repository": "https://github.com/cohere-ai/cohere-typescript",
     "main": "./index.js",

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -237,8 +237,8 @@ export class CohereClient {
             headers: {
                 Authorization: await this._getAuthorizationHeader(),
                 "X-Fern-Language": "JavaScript",
-                "X-Fern-SDK-Name": "@fern-api/cohere",
-                "X-Fern-SDK-Version": "0.0.19",
+                "X-Fern-SDK-Name": "cohere-ai",
+                "X-Fern-SDK-Version": "7.0.0",
             },
             contentType: "application/json",
             body: {
@@ -570,8 +570,8 @@ export class CohereClient {
             headers: {
                 Authorization: await this._getAuthorizationHeader(),
                 "X-Fern-Language": "JavaScript",
-                "X-Fern-SDK-Name": "@fern-api/cohere",
-                "X-Fern-SDK-Version": "0.0.19",
+                "X-Fern-SDK-Name": "cohere-ai",
+                "X-Fern-SDK-Version": "7.0.0",
             },
             body: {
                 ...(await serializers.ChatRequest.jsonOrThrow(request, { unrecognizedObjectKeys: "strip" })),

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -8,6 +8,7 @@ import * as Cohere from "./api";
 import * as serializers from "./serialization";
 import urlJoin from "url-join";
 import * as errors from "./errors";
+import { Stream } from "core/streaming-fetcher/StreamingFetcher";
 
 export declare namespace CohereClient {
     interface Options {
@@ -226,7 +227,7 @@ export class CohereClient {
     public async chat(
         request: Cohere.ChatRequest,
         requestOptions?: CohereClient.RequestOptions
-    ): Promise<Cohere.ChatResponse> {
+    ): Promise<Cohere.NonStreamedChatResponse> {
         const _response = await core.fetcher({
             url: urlJoin(
                 (await core.Supplier.get(this._options.environment)) ?? environments.CohereEnvironment.Production,
@@ -236,15 +237,18 @@ export class CohereClient {
             headers: {
                 Authorization: await this._getAuthorizationHeader(),
                 "X-Fern-Language": "JavaScript",
-                "X-Fern-SDK-Name": "cohere-ai",
-                "X-Fern-SDK-Version": "7.0.0",
+                "X-Fern-SDK-Name": "@fern-api/cohere",
+                "X-Fern-SDK-Version": "0.0.19",
             },
             contentType: "application/json",
-            body: await serializers.ChatRequest.jsonOrThrow(request, { unrecognizedObjectKeys: "strip" }),
+            body: {
+                ...(await serializers.ChatRequest.jsonOrThrow(request, { unrecognizedObjectKeys: "strip" })),
+                stream: false,
+            },
             timeoutMs: requestOptions?.timeoutInSeconds != null ? requestOptions.timeoutInSeconds * 1000 : 60000,
         });
         if (_response.ok) {
-            return await serializers.ChatResponse.parseOrThrow(_response.body, {
+            return await serializers.NonStreamedChatResponse.parseOrThrow(_response.body, {
                 unrecognizedObjectKeys: "passthrough",
                 allowUnrecognizedUnionMembers: true,
                 allowUnrecognizedEnumValues: true,
@@ -551,6 +555,38 @@ export class CohereClient {
                     message: _response.error.errorMessage,
                 });
         }
+    }
+
+    public async chatStream(
+        request: Cohere.ChatRequest,
+        requestOptions?: CohereClient.RequestOptions
+    ): Promise<Stream<Cohere.StreamedChatResponse>> {
+        return await core.streamingFetcher({
+            url: urlJoin(
+                (await core.Supplier.get(this._options.environment)) ?? environments.CohereEnvironment.Production,
+                "v1/chat"
+            ),
+            method: "POST",
+            headers: {
+                Authorization: await this._getAuthorizationHeader(),
+                "X-Fern-Language": "JavaScript",
+                "X-Fern-SDK-Name": "@fern-api/cohere",
+                "X-Fern-SDK-Version": "0.0.19",
+            },
+            body: {
+                ...(await serializers.ChatRequest.jsonOrThrow(request, { unrecognizedObjectKeys: "strip" })),
+                stream: true,
+            },
+            timeoutMs: requestOptions?.timeoutInSeconds != null ? requestOptions.timeoutInSeconds * 1000 : 60000,
+            parse: async (data) => {
+                return await serializers.StreamedChatResponse.parseOrThrow(data, {
+                    unrecognizedObjectKeys: "passthrough",
+                    allowUnrecognizedUnionMembers: true,
+                    allowUnrecognizedEnumValues: true,
+                    breadcrumbsPrefix: ["response"],
+                });
+            },
+        });
     }
 
     protected async _getAuthorizationHeader() {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,3 +1,4 @@
 export * from "./fetcher";
+export * from "./streaming-fetcher";
 export * from "./auth";
 export * as serialization from "./schemas";

--- a/src/core/streaming-fetcher/StreamingFetcher.ts
+++ b/src/core/streaming-fetcher/StreamingFetcher.ts
@@ -1,0 +1,93 @@
+import axios, { AxiosAdapter, AxiosResponse } from "axios";
+import qs from "qs";
+import { Readable } from "stream";
+
+export type StreamingFetchFunction<T> = (args: StreamingFetcher.Args<T>) => Promise<Stream<T>>;
+
+export declare namespace StreamingFetcher {
+    export interface Args<T> {
+        url: string;
+        method: string;
+        headers?: Record<string, string | undefined>;
+        queryParameters?: Record<string, string>;
+        body?: unknown;
+        timeoutMs?: number;
+        withCredentials?: boolean;
+        adapter?: AxiosAdapter;
+        parse: (val: unknown) => Promise<T>;
+
+        terminator?: string;
+    }
+
+    export interface Response {
+        data: Readable;
+        headers: Record<string, any>;
+    }
+}
+
+export async function streamingFetcher<T>(args: StreamingFetcher.Args<T>): Promise<Stream<T>> {
+    const headers: Record<string, string> = {};
+    if (args.body !== undefined) {
+        headers["Content-Type"] = "application/json";
+    }
+    if (args.headers != null) {
+        for (const [key, value] of Object.entries(args.headers)) {
+            if (value != null) {
+                headers[key] = value;
+            }
+        }
+    }
+
+    const response = await axios({
+        url: args.url,
+        params: args.queryParameters,
+        paramsSerializer: (params) => {
+            return qs.stringify(params);
+        },
+        method: args.method,
+        headers,
+        data: args.body,
+        timeout: args.timeoutMs,
+        transitional: {
+            clarifyTimeoutError: true,
+        },
+        withCredentials: args.withCredentials,
+        maxBodyLength: Infinity,
+        maxContentLength: Infinity,
+        responseType: "stream",
+        adapter: args.adapter,
+    });
+
+    return new Stream(response, args.parse);
+}
+
+export class Stream<T> implements AsyncIterable<T> {
+    private response: AxiosResponse<any, any>;
+    private parse: (val: unknown) => Promise<T>;
+
+    constructor(response: AxiosResponse<any, any>, parse: (val: unknown) => Promise<T>) {
+        this.response = response;
+        this.parse = parse;
+    }
+
+    private async *iterMessages(): AsyncGenerator<T, void, unknown> {
+        let previous = "";
+        for await (const chunk of this.response.data) {
+            const bufferChunk = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+            previous += bufferChunk;
+            let eolIndex: number;
+            while ((eolIndex = previous.indexOf("\n")) >= 0) {
+                const line = previous.slice(0, eolIndex).trimEnd();
+                const message = await this.parse(JSON.parse(line));
+                yield message;
+                previous = previous.slice(eolIndex + 1);
+            }
+        }
+    }
+
+    async *[Symbol.asyncIterator](): AsyncIterator<T, void, unknown> {
+        for await (const message of this.iterMessages()) {
+            yield message;
+        }
+    }
+}

--- a/src/core/streaming-fetcher/getHeader.ts
+++ b/src/core/streaming-fetcher/getHeader.ts
@@ -1,0 +1,10 @@
+import { StreamingFetcher } from "./StreamingFetcher";
+
+export function getHeader(response: StreamingFetcher.Response, header: string): string | undefined {
+    for (const [headerKey, headerValue] of Object.entries(response.headers)) {
+        if (headerKey.toLowerCase() === header.toLowerCase()) {
+            return headerValue;
+        }
+    }
+    return undefined;
+}

--- a/src/core/streaming-fetcher/index.ts
+++ b/src/core/streaming-fetcher/index.ts
@@ -1,0 +1,3 @@
+export { getHeader } from "./getHeader";
+export { streamingFetcher } from "./StreamingFetcher";
+export type { StreamingFetcher, StreamingFetchFunction } from "./StreamingFetcher";


### PR DESCRIPTION
In this PR, we manually copy over the fern-generated streaming method for chat completion. This is necessary while we work on a change to get the core OpenAPI upgraded with the `x-fern-streaming` extension.