### PR TITLE
fix: enable stream option in api

### DIFF
--- a/src/api/client/requests/ChatStreamRequest.ts
+++ b/src/api/client/requests/ChatStreamRequest.ts
@@ -90,4 +90,6 @@ export interface ChatStreamRequest {
     frequencyPenalty?: number;
     /** Defaults to `0.0`, min value of `0.0`, max value of `1.0`. Can be used to reduce repetitiveness of generated tokens. Similar to `frequency_penalty`, except that this penalty is applied equally to all tokens that have already appeared, regardless of their exact frequencies. */
     presencePenalty?: number;
+    /** Stream requests from api. */
+    stream: true;
 }

--- a/src/api/client/requests/GenerateStreamRequest.ts
+++ b/src/api/client/requests/GenerateStreamRequest.ts
@@ -100,4 +100,6 @@ export interface GenerateStreamRequest {
     logitBias?: Record<string, number>;
     /** When enabled, the user's prompt will be sent to the model without any pre-processing. */
     rawPrompting?: boolean;
+    /** Stream requests from api. */
+    stream: true;
 }

--- a/src/serialization/client/requests/ChatStreamRequest.ts
+++ b/src/serialization/client/requests/ChatStreamRequest.ts
@@ -36,7 +36,9 @@ export const ChatStreamRequest: core.serialization.Schema<serializers.ChatStream
         temperature: core.serialization.number().optional(),
         frequencyPenalty: core.serialization.property("frequency_penalty", core.serialization.number().optional()),
         presencePenalty: core.serialization.property("presence_penalty", core.serialization.number().optional()),
-    });
+    }).withParsedProperties({
+        stream: true
+    })
 
 export declare namespace ChatStreamRequest {
     interface Raw {

--- a/src/serialization/client/requests/GenerateStreamRequest.ts
+++ b/src/serialization/client/requests/GenerateStreamRequest.ts
@@ -38,7 +38,9 @@ export const GenerateStreamRequest: core.serialization.Schema<
         core.serialization.record(core.serialization.string(), core.serialization.number()).optional()
     ),
     rawPrompting: core.serialization.property("raw_prompting", core.serialization.boolean().optional()),
-});
+}).withParsedProperties({
+    stream: true
+})
 
 export declare namespace GenerateStreamRequest {
     interface Raw {


### PR DESCRIPTION
Previously, stream APIs were broken because the `stream: true` parameter in the request body was not being passed in the fetch request. This PR uses `withParsedProperties` to always enable the stream property on `generateStream` and `chatStream` requests.