### PR TITLE
fix: append fileName to the formData

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -14,3 +14,4 @@ src/index.ts
 src/aws-utils.ts
 src/core/streaming-fetcher/streaming-utils.ts
 src/ClientV2.ts
+src/api/resources/datasets/client/Client.ts

--- a/src/api/resources/datasets/client/Client.ts
+++ b/src/api/resources/datasets/client/Client.ts
@@ -280,9 +280,9 @@ export class Datasets {
         }
 
         const _request = await core.newFormData();
-        await _request.appendFile("data", data);
+        await _request.appendFile("data", data, (data as File)?.name);
         if (evalData != null) {
-            await _request.appendFile("eval_data", evalData);
+            await _request.appendFile("eval_data", evalData, (evalData as File)?.name);
         }
 
         const _maybeEncodedRequest = await _request.getRequest();


### PR DESCRIPTION
### Description

Due to the missing file name, the endpoint doesn't know the file type and their validation fails.