### PR TITLE
Fix v1 environment issue

### DIFF
--- a/src/CustomClient.ts
+++ b/src/CustomClient.ts
@@ -1,0 +1,16 @@
+import { CohereClient } from "./Client";
+
+export class CustomClient extends CohereClient {
+    constructor(protected readonly _options: CohereClient.Options = {}) {
+        try {
+            // if url ends with /v1, drop it for back compat
+            const match = /\/v1\/?$/
+            const fixed = _options.environment?.toString().replace(match, "");
+            if (fixed !== _options.environment?.toString()) {
+                _options.environment = fixed
+            }
+        } catch { }
+
+        super(_options)
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export * as Cohere from "./api";
 export { BedrockClient } from "./BedrockClient";
-export { CohereClient } from "./Client";
 export { CohereClientV2 } from "./ClientV2";
+export { CustomClient as CohereClient } from "./CustomClient";
 export { CohereEnvironment } from "./environments";
 export { CohereError, CohereTimeoutError } from "./errors";
 export { SagemakerClient } from "./SagemakerClient";

--- a/src/test/__snapshots__/client.test.ts.snap
+++ b/src/test/__snapshots__/client.test.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`v1 back compat https://api.cohere.com/ 1`] = `"https://api.cohere.com/v1/chat"`;
+
+exports[`v1 back compat https://api.cohere.com/v1 1`] = `"https://api.cohere.com/v1/chat"`;
+
+exports[`v1 back compat https://api.cohere.com/v1/ 1`] = `"https://api.cohere.com/v1/chat"`;
+
+exports[`v1 back compat https://api.cohere.com/v1// 1`] = `"https://api.cohere.com/v1/v1/chat"`;
+
+exports[`v1 back compat https://api.cohere.com/v2 1`] = `"https://api.cohere.com/v2/v1/chat"`;

--- a/src/test/client.test.ts
+++ b/src/test/client.test.ts
@@ -1,0 +1,29 @@
+import { describe, test } from "@jest/globals";
+import { CohereClient } from "../index";
+
+describe("v1 back compat", () => {
+    test.each([
+        "https://api.cohere.com/",
+        "https://api.cohere.com/v1",
+        "https://api.cohere.com/v1/",
+        "https://api.cohere.com/v1//",
+        "https://api.cohere.com/v2",
+    ])("%s", async (environment) => {
+        let url = ""
+
+        const cohere = new CohereClient({
+            token: "token",
+            environment,
+            fetcher: (async (opts) => {
+                url = opts.url
+                throw "we're done"
+            })
+        })
+
+        try {
+            await cohere.chat({ message: "hello" })
+        } catch { }
+
+        expect(url).toMatchSnapshot()
+    })
+});

--- a/src/test/tests.test.ts
+++ b/src/test/tests.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "@jest/globals";
 import { StreamedChatResponse } from "api";
-import { CohereClient } from "../Client";
+import { CohereClient } from "../index";
 
 const cohere = new CohereClient({
     token: process.env.COHERE_API_KEY!,


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR introduces a new `CustomClient` class that extends the `CohereClient` class. The `CustomClient` class includes a constructor that performs a check on the `_options.environment` value, removing any trailing "/v1" for backward compatibility.

**Code Changes:**
- Added a new file, `CustomClient.ts`, which contains the `CustomClient` class definition.
- Updated the import statement in index.ts to import `CustomClient` from `CustomClient.ts` and export it as `CohereClient`.
- Added a new test file, `client.test.ts`, with corresponding snapshot file `client.test.ts.snap`, to test the backward compatibility of the `CohereClient` class.
- Updated the import statement in `tests.test.ts` to import `CohereClient` from `index.ts`.

<!-- end-generated-description -->