### PR TITLE
Add V2 AWS clients

### DIFF
--- a/src/AwsClient.ts
+++ b/src/AwsClient.ts
@@ -1,7 +1,15 @@
+import { CohereClientV2 } from 'ClientV2';
 import { AwsProps } from './aws-utils';
 import { CohereClient } from "./Client";
 
 export class AwsClient extends CohereClient {
+    constructor(_options: CohereClient.Options & AwsProps) {
+        _options.token = "n/a"; // AWS clients don't need a token but setting to this to a string so Fern doesn't complain
+        super(_options);
+    }
+}
+
+export class AwsClientV2 extends CohereClientV2 {
     constructor(_options: CohereClient.Options & AwsProps) {
         _options.token = "n/a"; // AWS clients don't need a token but setting to this to a string so Fern doesn't complain
         super(_options);

--- a/src/AwsClient.ts
+++ b/src/AwsClient.ts
@@ -1,6 +1,6 @@
-import { CohereClientV2 } from 'ClientV2';
 import { AwsProps } from './aws-utils';
 import { CohereClient } from "./Client";
+import { CohereClientV2 } from './ClientV2';
 
 export class AwsClient extends CohereClient {
     constructor(_options: CohereClient.Options & AwsProps) {

--- a/src/BedrockClient.ts
+++ b/src/BedrockClient.ts
@@ -1,8 +1,14 @@
 import { AwsProps, fetchOverride } from './aws-utils';
-import { AwsClient } from './AwsClient';
+import { AwsClient, AwsClientV2 } from './AwsClient';
 import { CohereClient } from "./Client";
 
 export class BedrockClient extends AwsClient {
+    constructor(_options: CohereClient.Options & AwsProps) {
+        super({ ..._options, fetcher: fetchOverride("bedrock", _options) });
+    }
+}
+
+export class BedrockClientV2 extends AwsClientV2 {
     constructor(_options: CohereClient.Options & AwsProps) {
         super({ ..._options, fetcher: fetchOverride("bedrock", _options) });
     }

--- a/src/SagemakerClient.ts
+++ b/src/SagemakerClient.ts
@@ -1,9 +1,15 @@
-import { AwsClient } from './AwsClient';
+import { AwsClient, AwsClientV2 } from './AwsClient';
 import { CohereClient } from "./Client";
 import { AwsProps, fetchOverride } from './aws-utils';
 
 
 export class SagemakerClient extends AwsClient {
+    constructor(_options: CohereClient.Options & AwsProps) {
+        super({ ..._options, fetcher: fetchOverride("sagemaker", _options) });
+    }
+}
+
+export class SagemakerClientV2 extends AwsClientV2 {
     constructor(_options: CohereClient.Options & AwsProps) {
         super({ ..._options, fetcher: fetchOverride("sagemaker", _options) });
     }


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR introduces new V2 clients for AWS, Bedrock, and Sagemaker. These clients extend the CohereClientV2 and include a constructor that sets the token to "n/a" and calls the super with the provided options.

- **src/AwsClient.ts**:
  - Imports `CohereClientV2` from `'ClientV2'`.
  - Adds a new `AwsClientV2` class that extends `CohereClientV2`.
  - The `AwsClientV2` constructor sets the token to `"n/a"` and calls the superclass constructor with the provided options.

- **src/BedrockClient.ts**:
  - Updates the import statement to include `AwsClientV2` from `'AwsClient'`.
  - Adds a new `BedrockClientV2` class that extends `AwsClientV2`.
  - The `BedrockClientV2` constructor calls the superclass constructor with the provided options and a custom fetcher.

- **src/SagemakerClient.ts**:
  - Updates the import statement to include `AwsClientV2` from `'AwsClient'`.
  - Adds a new `SagemakerClientV2` class that extends `AwsClientV2`.
  - The `SagemakerClientV2` constructor calls the superclass constructor with the provided options and a custom fetcher.

<!-- end-generated-description -->