### PR TITLE
Fix reasoning model issue by updating chat API to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,13 @@ This SDK is in beta, and while we will try to avoid it, there may be breaking ch
 While we value open-source contributions to this SDK, the code is generated programmatically. Additions made directly would have to be moved over to our generation code, otherwise they would be overwritten upon the next generated release. Feel free to open a PR as a proof of concept, but know that we will not be able to merge it as-is. We suggest opening an issue first to discuss with us!
 
 On the other hand, contributions to the README are always very welcome!
+
+## Fix: Chat API Version Update
+
+Updated chat endpoint from `v1` to `v2` to ensure compatibility with reasoning models.
+
+### Why?
+The `v1` endpoint does not support reasoning models, causing issues during usage.
+
+### Solution
+Switched to `v2/chat` endpoint for proper support.

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -103,7 +103,7 @@ export class CohereClient {
                 (await core.Supplier.get(this._options.baseUrl)) ??
                     (await core.Supplier.get(this._options.environment)) ??
                     environments.CohereEnvironment.Production,
-                "v1/chat",
+                "v2/chat",
             ),
             method: "POST",
             headers: _headers,


### PR DESCRIPTION
## 🛠 Fix: Update Chat API to v2 for Reasoning Model Support

### 📌 Problem

The `v1/chat` endpoint does not support reasoning models, causing issues when trying to use them.

### ✅ Solution

* Updated endpoint from `v1/chat` → `v2/chat`
* Ensures proper compatibility with reasoning models

### 🔍 Changes Made

* Modified API endpoint in fetch request
* No changes to existing logic or UI

### 🚀 Impact

* Fixes reasoning model usage
* Improves API compatibility
* No breaking changes

### 🧪 Testing

* Verified reasoning model works correctly with v2
* No regressions observed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low code complexity but changes the network endpoint used by `chatStream`, which could alter response shape/behavior or break users if their backend expects `v1` semantics.
> 
> **Overview**
> Switches the SDK’s streamed chat request (`chatStream`) from hitting `v1/chat` to `v2/chat` to support reasoning models.
> 
> Adds a short README note documenting the endpoint version update and the rationale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98fc5e4f986af0ad3b660e88ef81cf02cd1e4aac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->