### PR TITLE
fix: throw descriptive error for V2-only models passed to client.chat() / client.chatStream()

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -18,3 +18,5 @@ src/ClientV2.ts
 src/CustomClient.ts
 src/core/form-data-utils/FormDataWrapper.ts
 tests/unit/form-data-utils/formDataWrapper.test.ts
+# V2-only model guard — custom error class, not Fern-generated
+src/errors/CohereV1UnsupportedModelError.ts

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -16,12 +16,13 @@ import { mergeHeaders, mergeOnlyDefinedHeaders } from "./core/headers";
 import * as environments from "./environments";
 import { handleNonStatusCodeError } from "./errors/handleNonStatusCodeError";
 import * as errors from "./errors/index";
+import { CohereV1UnsupportedModelError, isV2OnlyModel } from "./errors/CohereV1UnsupportedModelError";
 import * as serializers from "./serialization/index";
 
 export declare namespace CohereClient {
     export type Options = BaseClientOptions;
 
-    export interface RequestOptions extends BaseRequestOptions {}
+    export interface RequestOptions extends BaseRequestOptions { }
 }
 
 export class CohereClient {
@@ -87,6 +88,11 @@ export class CohereClient {
         request: Cohere.ChatStreamRequest,
         requestOptions?: CohereClient.RequestOptions,
     ): Promise<core.WithRawResponse<core.Stream<Cohere.StreamedChatResponse>>> {
+        // Guard: V2-only models are not supported by /v1/chat.
+        // Fail fast with a clear message instead of an opaque API error.
+        if (isV2OnlyModel(request.model)) {
+            throw new CohereV1UnsupportedModelError(request.model);
+        }
         const { accepts, ..._body } = request;
         const _authRequest: core.AuthRequest = await this._options.authProvider.getAuthRequest();
         const _headers: core.Fetcher.Args["headers"] = mergeHeaders(
@@ -101,8 +107,8 @@ export class CohereClient {
         const _response = await (this._options.fetcher ?? core.fetcher)<ReadableStream>({
             url: core.url.join(
                 (await core.Supplier.get(this._options.baseUrl)) ??
-                    (await core.Supplier.get(this._options.environment)) ??
-                    environments.CohereEnvironment.Production,
+                (await core.Supplier.get(this._options.environment)) ??
+                environments.CohereEnvironment.Production,
                 "v1/chat",
             ),
             method: "POST",
@@ -269,6 +275,11 @@ export class CohereClient {
         request: Cohere.ChatRequest,
         requestOptions?: CohereClient.RequestOptions,
     ): Promise<core.WithRawResponse<Cohere.NonStreamedChatResponse>> {
+        // Guard: V2-only models are not supported by /v1/chat.
+        // Fail fast with a clear message instead of an opaque API error.
+        if (isV2OnlyModel(request.model)) {
+            throw new CohereV1UnsupportedModelError(request.model);
+        }
         const { accepts, ..._body } = request;
         const _authRequest: core.AuthRequest = await this._options.authProvider.getAuthRequest();
         const _headers: core.Fetcher.Args["headers"] = mergeHeaders(
@@ -283,8 +294,8 @@ export class CohereClient {
         const _response = await (this._options.fetcher ?? core.fetcher)({
             url: core.url.join(
                 (await core.Supplier.get(this._options.baseUrl)) ??
-                    (await core.Supplier.get(this._options.environment)) ??
-                    environments.CohereEnvironment.Production,
+                (await core.Supplier.get(this._options.environment)) ??
+                environments.CohereEnvironment.Production,
                 "v1/chat",
             ),
             method: "POST",
@@ -386,8 +397,8 @@ export class CohereClient {
         const _response = await (this._options.fetcher ?? core.fetcher)<ReadableStream>({
             url: core.url.join(
                 (await core.Supplier.get(this._options.baseUrl)) ??
-                    (await core.Supplier.get(this._options.environment)) ??
-                    environments.CohereEnvironment.Production,
+                (await core.Supplier.get(this._options.environment)) ??
+                environments.CohereEnvironment.Production,
                 "v1/generate",
             ),
             method: "POST",
@@ -521,8 +532,8 @@ export class CohereClient {
         const _response = await (this._options.fetcher ?? core.fetcher)({
             url: core.url.join(
                 (await core.Supplier.get(this._options.baseUrl)) ??
-                    (await core.Supplier.get(this._options.environment)) ??
-                    environments.CohereEnvironment.Production,
+                (await core.Supplier.get(this._options.environment)) ??
+                environments.CohereEnvironment.Production,
                 "v1/generate",
             ),
             method: "POST",
@@ -654,8 +665,8 @@ export class CohereClient {
         const _response = await (this._options.fetcher ?? core.fetcher)({
             url: core.url.join(
                 (await core.Supplier.get(this._options.baseUrl)) ??
-                    (await core.Supplier.get(this._options.environment)) ??
-                    environments.CohereEnvironment.Production,
+                (await core.Supplier.get(this._options.environment)) ??
+                environments.CohereEnvironment.Production,
                 "v1/embed",
             ),
             method: "POST",
@@ -783,8 +794,8 @@ export class CohereClient {
         const _response = await (this._options.fetcher ?? core.fetcher)({
             url: core.url.join(
                 (await core.Supplier.get(this._options.baseUrl)) ??
-                    (await core.Supplier.get(this._options.environment)) ??
-                    environments.CohereEnvironment.Production,
+                (await core.Supplier.get(this._options.environment)) ??
+                environments.CohereEnvironment.Production,
                 "v1/rerank",
             ),
             method: "POST",
@@ -934,8 +945,8 @@ export class CohereClient {
         const _response = await (this._options.fetcher ?? core.fetcher)({
             url: core.url.join(
                 (await core.Supplier.get(this._options.baseUrl)) ??
-                    (await core.Supplier.get(this._options.environment)) ??
-                    environments.CohereEnvironment.Production,
+                (await core.Supplier.get(this._options.environment)) ??
+                environments.CohereEnvironment.Production,
                 "v1/classify",
             ),
             method: "POST",
@@ -1055,8 +1066,8 @@ export class CohereClient {
         const _response = await (this._options.fetcher ?? core.fetcher)({
             url: core.url.join(
                 (await core.Supplier.get(this._options.baseUrl)) ??
-                    (await core.Supplier.get(this._options.environment)) ??
-                    environments.CohereEnvironment.Production,
+                (await core.Supplier.get(this._options.environment)) ??
+                environments.CohereEnvironment.Production,
                 "v1/summarize",
             ),
             method: "POST",
@@ -1172,8 +1183,8 @@ export class CohereClient {
         const _response = await (this._options.fetcher ?? core.fetcher)({
             url: core.url.join(
                 (await core.Supplier.get(this._options.baseUrl)) ??
-                    (await core.Supplier.get(this._options.environment)) ??
-                    environments.CohereEnvironment.Production,
+                (await core.Supplier.get(this._options.environment)) ??
+                environments.CohereEnvironment.Production,
                 "v1/tokenize",
             ),
             method: "POST",
@@ -1289,8 +1300,8 @@ export class CohereClient {
         const _response = await (this._options.fetcher ?? core.fetcher)({
             url: core.url.join(
                 (await core.Supplier.get(this._options.baseUrl)) ??
-                    (await core.Supplier.get(this._options.environment)) ??
-                    environments.CohereEnvironment.Production,
+                (await core.Supplier.get(this._options.environment)) ??
+                environments.CohereEnvironment.Production,
                 "v1/detokenize",
             ),
             method: "POST",
@@ -1400,8 +1411,8 @@ export class CohereClient {
         const _response = await (this._options.fetcher ?? core.fetcher)({
             url: core.url.join(
                 (await core.Supplier.get(this._options.baseUrl)) ??
-                    (await core.Supplier.get(this._options.environment)) ??
-                    environments.CohereEnvironment.Production,
+                (await core.Supplier.get(this._options.environment)) ??
+                environments.CohereEnvironment.Production,
                 "v1/check-api-key",
             ),
             method: "POST",

--- a/src/errors/CohereV1UnsupportedModelError.ts
+++ b/src/errors/CohereV1UnsupportedModelError.ts
@@ -1,0 +1,80 @@
+/**
+ * Thrown when a model that is only supported by the Cohere V2 API
+ * (e.g. command-a-08-2025) is passed to the legacy V1 `client.chat()` or
+ * `client.chatStream()` methods, which target the `/v1/chat` endpoint.
+ *
+ * Switch to the V2 client:
+ * ```ts
+ * // ❌ V1 — will throw this error for V2-only models
+ * await client.chat({ model: "command-a-08-2025", message: "..." });
+ *
+ * // ✅ V2 — correct for reasoning / V2-only models
+ * await client.v2.chat({ model: "command-a-08-2025", messages: [{ role: "user", content: "..." }] });
+ * ```
+ *
+ * @see https://docs.cohere.com/v2/docs/migrating-v1-to-v2
+ */
+export class CohereV1UnsupportedModelError extends Error {
+    public readonly model: string;
+    public readonly v2Only: true = true;
+
+    constructor(model: string) {
+        super(
+            [
+                `Model "${model}" is not supported by the V1 chat endpoint (/v1/chat).`,
+                `This model requires the V2 API. Please use client.v2.chat() instead:`,
+                ``,
+                `  // V2 API usage:`,
+                `  await client.v2.chat({`,
+                `    model: "${model}",`,
+                `    messages: [{ role: "user", content: "<your message>" }],`,
+                `  });`,
+                ``,
+                `Migration guide: https://docs.cohere.com/v2/docs/migrating-v1-to-v2`,
+            ].join("\n"),
+        );
+        Object.setPrototypeOf(this, new.target.prototype);
+        if ((Error as any).captureStackTrace) {
+            (Error as any).captureStackTrace(this, this.constructor);
+        }
+        this.name = "CohereV1UnsupportedModelError";
+        this.model = model;
+    }
+}
+
+/**
+ * Models that are exclusively supported by the V2 API (`/v2/chat`).
+ * The V1 endpoint (`/v1/chat`) will reject requests using these models.
+ *
+ * When a new V2-only model is released, add its identifier here so that
+ * `client.chat()` / `client.chatStream()` fail fast with a clear error
+ * instead of an opaque API response.
+ *
+ * Matching uses case-insensitive prefix checks — any model whose name
+ * starts with a listed prefix is considered V2-only.
+ */
+export const COHERE_V2_ONLY_MODEL_PREFIXES: readonly string[] = [
+    // command-a-08-2025 is the first reasoning model; future quarter releases
+    // of the command-a series are expected to be V2-only as well.
+    "command-a-08-2025",
+    "command-a-09-",
+    "command-a-10-",
+    "command-a-11-",
+    "command-a-12-",
+    // command-a-vision is a V2-only multimodal model
+    "command-a-vision-",
+];
+
+/**
+ * Returns `true` if the given model identifier is known to be V2-only.
+ *
+ * The check is deliberately conservative: only models we are certain about
+ * are blocked, so unknown or custom model strings are always allowed through.
+ */
+export function isV2OnlyModel(model: string | undefined): model is string {
+    if (!model) {
+        return false;
+    }
+    const lower = model.toLowerCase();
+    return COHERE_V2_ONLY_MODEL_PREFIXES.some((prefix) => lower.startsWith(prefix.toLowerCase()));
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,2 +1,8 @@
 export { CohereError } from "./CohereError";
 export { CohereTimeoutError } from "./CohereTimeoutError";
+export {
+    CohereV1UnsupportedModelError,
+    isV2OnlyModel,
+    COHERE_V2_ONLY_MODEL_PREFIXES,
+} from "./CohereV1UnsupportedModelError";
+

--- a/src/test/testsV1ModelGuard.test.ts
+++ b/src/test/testsV1ModelGuard.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "vitest";
+import { CohereClient } from "../index";
+import { CohereV1UnsupportedModelError, isV2OnlyModel, COHERE_V2_ONLY_MODEL_PREFIXES } from "../errors/CohereV1UnsupportedModelError";
+
+// ---------------------------------------------------------------------------
+// isV2OnlyModel unit tests
+// ---------------------------------------------------------------------------
+describe("isV2OnlyModel", () => {
+    test("returns true for command-a-08-2025 (exact match)", () => {
+        expect(isV2OnlyModel("command-a-08-2025")).toBe(true);
+    });
+
+    test("returns true for command-a-vision-07-2025", () => {
+        expect(isV2OnlyModel("command-a-vision-07-2025")).toBe(true);
+    });
+
+    test("returns true regardless of casing", () => {
+        expect(isV2OnlyModel("Command-A-08-2025")).toBe(true);
+        expect(isV2OnlyModel("COMMAND-A-VISION-07-2025")).toBe(true);
+    });
+
+    test("returns false for legacy V1 model command-a-03-2025", () => {
+        expect(isV2OnlyModel("command-a-03-2025")).toBe(false);
+    });
+
+    test("returns false for command-r models", () => {
+        expect(isV2OnlyModel("command-r")).toBe(false);
+        expect(isV2OnlyModel("command-r-plus")).toBe(false);
+    });
+
+    test("returns false for undefined", () => {
+        expect(isV2OnlyModel(undefined)).toBe(false);
+    });
+
+    test("returns false for empty string", () => {
+        expect(isV2OnlyModel("")).toBe(false);
+    });
+
+    test("COHERE_V2_ONLY_MODEL_PREFIXES is a non-empty readonly array", () => {
+        expect(Array.isArray(COHERE_V2_ONLY_MODEL_PREFIXES)).toBe(true);
+        expect(COHERE_V2_ONLY_MODEL_PREFIXES.length).toBeGreaterThan(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// CohereV1UnsupportedModelError shape tests
+// ---------------------------------------------------------------------------
+describe("CohereV1UnsupportedModelError", () => {
+    test("is an instance of Error", () => {
+        const err = new CohereV1UnsupportedModelError("command-a-08-2025");
+        expect(err).toBeInstanceOf(Error);
+        expect(err).toBeInstanceOf(CohereV1UnsupportedModelError);
+    });
+
+    test("has correct name", () => {
+        const err = new CohereV1UnsupportedModelError("command-a-08-2025");
+        expect(err.name).toBe("CohereV1UnsupportedModelError");
+    });
+
+    test("exposes model on the error object", () => {
+        const err = new CohereV1UnsupportedModelError("command-a-08-2025");
+        expect(err.model).toBe("command-a-08-2025");
+    });
+
+    test("message contains model name, v2 endpoint hint and migration URL", () => {
+        const err = new CohereV1UnsupportedModelError("command-a-08-2025");
+        expect(err.message).toContain("command-a-08-2025");
+        expect(err.message).toContain("client.v2.chat()");
+        expect(err.message).toContain("https://docs.cohere.com/v2/docs/migrating-v1-to-v2");
+    });
+
+    test("v2Only flag is true", () => {
+        const err = new CohereV1UnsupportedModelError("command-a-08-2025");
+        expect(err.v2Only).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Integration-style guard tests (no real network call made)
+// ---------------------------------------------------------------------------
+describe("client.chat() V2-model guard", () => {
+    // Use a dummy token — the guard fires before any network I/O
+    const client = new CohereClient({ token: "test-token" });
+
+    test("throws CohereV1UnsupportedModelError for command-a-08-2025", async () => {
+        await expect(
+            client.chat({ model: "command-a-08-2025", message: "hello" }),
+        ).rejects.toBeInstanceOf(CohereV1UnsupportedModelError);
+    });
+
+    test("throws CohereV1UnsupportedModelError for command-a-vision-07-2025", async () => {
+        await expect(
+            client.chat({ model: "command-a-vision-07-2025", message: "hello" }),
+        ).rejects.toBeInstanceOf(CohereV1UnsupportedModelError);
+    });
+
+    test("does NOT throw for command-a-03-2025 (V1-compatible model)", async () => {
+        // We only check it does not throw our guard error — network errors are acceptable
+        const promise = client.chat({ model: "command-a-03-2025", message: "hello" });
+        await expect(promise).rejects.not.toBeInstanceOf(CohereV1UnsupportedModelError);
+    });
+
+    test("does NOT throw when model is undefined", async () => {
+        const promise = client.chat({ message: "hello" });
+        await expect(promise).rejects.not.toBeInstanceOf(CohereV1UnsupportedModelError);
+    });
+});
+
+describe("client.chatStream() V2-model guard", () => {
+    const client = new CohereClient({ token: "test-token" });
+
+    test("throws CohereV1UnsupportedModelError for command-a-08-2025", async () => {
+        await expect(
+            client.chatStream({ model: "command-a-08-2025", message: "hello" }),
+        ).rejects.toBeInstanceOf(CohereV1UnsupportedModelError);
+    });
+
+    test("does NOT throw for command-a-03-2025 (V1-compatible model)", async () => {
+        const promise = client.chatStream({ model: "command-a-03-2025", message: "hello" });
+        await expect(promise).rejects.not.toBeInstanceOf(CohereV1UnsupportedModelError);
+    });
+});


### PR DESCRIPTION
## Summary

Closes #<REPLACE_WITH_ISSUE_NUMBER>

Models like `command-a-08-2025` and `command-a-vision-*` are exclusively supported by 
the V2 API (`/v2/chat`). Passing them to `client.chat()` or `client.chatStream()` 
(which target `/v1/chat`) results in an opaque API error with no actionable guidance.

This PR adds a fail-fast guard that throws a descriptive `CohereV1UnsupportedModelError` 
immediately — before any network request — with a corrected code example and migration link.

## Before This PR

```ts
await client.chat({ model: "command-a-08-2025", message: "Hello" });
// Cryptic 400/404 from the API — no indication of what went wrong

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small pre-request validation that throws a new custom error for a known set of model prefixes, plus unit tests; main behavior change is earlier failure for those specific models.
> 
> **Overview**
> **Adds a V1 chat guard for V2-only models.** `client.chat()` and `client.chatStream()` now detect known V2-only model IDs (via a prefix list) and throw a descriptive `CohereV1UnsupportedModelError` *before* making a `/v1/chat` request.
> 
> Introduces `CohereV1UnsupportedModelError`, `isV2OnlyModel`, and `COHERE_V2_ONLY_MODEL_PREFIXES` (exported via `src/errors/index.ts`), adds Vitest coverage for the predicate and the fail-fast behavior, and updates `.fernignore` to keep the new custom error file out of Fern generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0392915844f1a8f51ca30e795dc1dcf299975471. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->