### PR TITLE
fix: update chat endpoint from v1 to v2 for new models

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -103,7 +103,7 @@ export class CohereClient {
                 (await core.Supplier.get(this._options.baseUrl)) ??
                     (await core.Supplier.get(this._options.environment)) ??
                     environments.CohereEnvironment.Production,
-                "v1/chat",
+                "v2/chat",
             ),
             method: "POST",
             headers: _headers,
@@ -183,7 +183,7 @@ export class CohereClient {
             }
         }
 
-        return handleNonStatusCodeError(_response.error, _response.rawResponse, "POST", "/v1/chat");
+        return handleNonStatusCodeError(_response.error, _response.rawResponse, "POST", "/v2/chat");
     }
 
     /**
@@ -285,7 +285,7 @@ export class CohereClient {
                 (await core.Supplier.get(this._options.baseUrl)) ??
                     (await core.Supplier.get(this._options.environment)) ??
                     environments.CohereEnvironment.Production,
-                "v1/chat",
+                "v2/chat",
             ),
             method: "POST",
             headers: _headers,
@@ -354,7 +354,7 @@ export class CohereClient {
             }
         }
 
-        return handleNonStatusCodeError(_response.error, _response.rawResponse, "POST", "/v1/chat");
+        return handleNonStatusCodeError(_response.error, _response.rawResponse, "POST", "/v2/chat");
     }
 
     /**


### PR DESCRIPTION
## Bug Fix

This PR updates the Cohere SDK chat endpoint from /v1/chat to /v2/chat.

## Problem

The SDK was using /v1/chat internally in chatStream, which is not compatible with newer models like command-a-reasoning-08-2025.

This caused the following error:
"invalid request: this model is not supported with '/v1/chat', please use '/v2/chat' instead"

## Solution

Updated the endpoint to use /v2/chat as required by the latest Cohere API.

## Impact

- Fixes failure for reasoning models
- Enables streaming chat to work correctly
- Aligns SDK with latest API changes

## Notes

This is a breaking change in Cohere API where /v2/chat is required for newer models.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the underlying API endpoint used by `chat`/`chatStream`, which can affect compatibility if `/v2/chat` differs in behavior or availability across environments.
> 
> **Overview**
> Updates `CohereClient.chat` and `CohereClient.chatStream` to POST to `v2/chat` (and updates the corresponding non-status-code error path from `/v1/chat` to `/v2/chat`). This aligns the SDK with models that require the newer chat endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d134839aea2f2597b7d1faf84a1a90b97201dcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->