### PR TITLE
Add package license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "cohere-ai",
     "version": "8.0.0",
     "private": false,
+    "license": "MIT",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/cohere-ai/cohere-typescript.git"


### PR DESCRIPTION
## Summary

- add MIT license metadata to the package manifest
- align npm metadata with the repository license

## Verification

- `npm view cohere-ai@latest name version license repository homepage bugs --json`
- `node -e "const p=require('./package.json'); if (p.license !== 'MIT') throw new Error('license mismatch'); console.log(p.name, p.version, p.license)"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single manifest metadata field with no effect on published code behavior or security paths.
> 
> **Overview**
> Adds **`"license": "MIT"`** to `package.json` so npm and registry consumers see the same SPDX identifier as the repo’s MIT `LICENSE` file.
> 
> No runtime, API, or dependency changes—metadata only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3ea15d50fe849ae22a2db890b5edd2d1881af36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->