### PR TITLE
fix: bind ClientV2 legacy methods to v1 client

### DIFF
--- a/src/ClientV2.ts
+++ b/src/ClientV2.ts
@@ -1,35 +1,34 @@
 import { V2Client } from "./api/resources/v2/client/Client";
 import { CohereClient } from "./Client";
-import * as core from "./core";
+import type * as core from "./core";
 
 // this class will require manual updates over time
 export class CohereClientV2 implements Omit<CohereClient, keyof V2Client | "v2">, Pick<V2Client, keyof V2Client> {
-    constructor(private _options: CohereClient.Options) {
-    }
+    constructor(private _options: CohereClient.Options) {}
 
     private client = new CohereClient(this._options);
     private clientV2 = new V2Client(this._options);
 
-    chat: typeof V2Client.prototype.chat = this.clientV2.chat.bind(this.clientV2)
-    chatStream: typeof V2Client.prototype.chatStream = this.clientV2.chatStream.bind(this.clientV2)
-    embed: typeof V2Client.prototype.embed = this.clientV2.embed.bind(this.clientV2)
-    rerank: typeof V2Client.prototype.rerank = this.clientV2.rerank.bind(this.clientV2)
+    chat: typeof V2Client.prototype.chat = this.clientV2.chat.bind(this.clientV2);
+    chatStream: typeof V2Client.prototype.chatStream = this.clientV2.chatStream.bind(this.clientV2);
+    embed: typeof V2Client.prototype.embed = this.clientV2.embed.bind(this.clientV2);
+    rerank: typeof V2Client.prototype.rerank = this.clientV2.rerank.bind(this.clientV2);
 
-    generateStream: typeof CohereClient.prototype.generateStream = this.client.generateStream.bind(this.clientV2)
-    generate: typeof CohereClient.prototype.generate = this.client.generate.bind(this.clientV2)
-    classify: typeof CohereClient.prototype.classify = this.client.classify.bind(this.clientV2)
-    summarize: typeof CohereClient.prototype.summarize = this.client.summarize.bind(this.clientV2)
-    tokenize: typeof CohereClient.prototype.tokenize = this.client.tokenize.bind(this.clientV2)
-    detokenize: typeof CohereClient.prototype.detokenize = this.client.detokenize.bind(this.clientV2)
-    checkApiKey: typeof CohereClient.prototype.checkApiKey = this.client.checkApiKey.bind(this.clientV2)
+    generateStream: typeof CohereClient.prototype.generateStream = this.client.generateStream.bind(this.client);
+    generate: typeof CohereClient.prototype.generate = this.client.generate.bind(this.client);
+    classify: typeof CohereClient.prototype.classify = this.client.classify.bind(this.client);
+    summarize: typeof CohereClient.prototype.summarize = this.client.summarize.bind(this.client);
+    tokenize: typeof CohereClient.prototype.tokenize = this.client.tokenize.bind(this.client);
+    detokenize: typeof CohereClient.prototype.detokenize = this.client.detokenize.bind(this.client);
+    checkApiKey: typeof CohereClient.prototype.checkApiKey = this.client.checkApiKey.bind(this.client);
 
-    embedJobs: typeof CohereClient.prototype.embedJobs = this.client.embedJobs
-    datasets: typeof CohereClient.prototype.datasets = this.client.datasets
-    connectors: typeof CohereClient.prototype.connectors = this.client.connectors
-    models: typeof CohereClient.prototype.models = this.client.models
-    finetuning: typeof CohereClient.prototype.finetuning = this.client.finetuning
-    batches: typeof CohereClient.prototype.batches = this.client.batches
-    audio: typeof CohereClient.prototype.audio = this.client.audio
+    embedJobs: typeof CohereClient.prototype.embedJobs = this.client.embedJobs;
+    datasets: typeof CohereClient.prototype.datasets = this.client.datasets;
+    connectors: typeof CohereClient.prototype.connectors = this.client.connectors;
+    models: typeof CohereClient.prototype.models = this.client.models;
+    finetuning: typeof CohereClient.prototype.finetuning = this.client.finetuning;
+    batches: typeof CohereClient.prototype.batches = this.client.batches;
+    audio: typeof CohereClient.prototype.audio = this.client.audio;
 
     async fetch(
         input: Request | string | URL,

--- a/src/test/client.test.ts
+++ b/src/test/client.test.ts
@@ -1,5 +1,5 @@
-import { describe, test, expect } from "vitest";
-import { CohereClient } from "../index";
+import { describe, expect, test } from "vitest";
+import { CohereClient, CohereClientV2 } from "../index";
 
 describe("v1 back compat", () => {
     test.each([
@@ -9,21 +9,55 @@ describe("v1 back compat", () => {
         "https://api.cohere.com/v1//",
         "https://api.cohere.com/v2",
     ])("%s", async (environment) => {
-        let url = ""
+        let url = "";
 
         const cohere = new CohereClient({
             token: "token",
             environment,
-            fetcher: (async (opts) => {
-                url = opts.url
-                throw "we're done"
-            })
-        })
+            fetcher: async (opts) => {
+                url = opts.url;
+                throw "we're done";
+            },
+        });
 
         try {
-            await cohere.chat({ message: "hello" })
-        } catch { }
+            await cohere.chat({ message: "hello" });
+        } catch {}
 
-        expect(url).toMatchSnapshot()
-    })
+        expect(url).toMatchSnapshot();
+    });
+
+    test("CohereClientV2 delegates legacy endpoints to the v1 client", async () => {
+        let url = "";
+        let body: unknown;
+
+        const cohere = new CohereClientV2({
+            token: "token",
+            fetcher: async (opts) => {
+                url = opts.url;
+                body = opts.body;
+                return {
+                    ok: false,
+                    error: {
+                        reason: "status-code",
+                        statusCode: 400,
+                        body: { message: "stop after capturing request" },
+                    },
+                    rawResponse: {
+                        headers: new Headers(),
+                        redirected: false,
+                        status: 400,
+                        statusText: "Bad Request",
+                        type: "basic" as ResponseType,
+                        url: opts.url,
+                    },
+                };
+            },
+        });
+
+        await expect(cohere.generate({ prompt: "hello" })).rejects.toThrow("stop after capturing request");
+
+        expect(url).toBe("https://api.cohere.com/v1/generate");
+        expect(body).toMatchObject({ prompt: "hello" });
+    });
 });


### PR DESCRIPTION
## Summary

Fix `CohereClientV2` legacy v1 endpoint methods so they are bound to the internal `CohereClient` instance instead of the `V2Client` instance.

`CohereClientV2` exposes v2 methods through `V2Client`, but also keeps legacy v1 methods such as `generate`, `classify`, `summarize`, `tokenize`, `detokenize`, and `checkApiKey` by delegating to an internal v1 `CohereClient`. Those delegated methods need the v1 client as `this`; binding them to `clientV2` can break legacy calls because the v2 client does not own the v1 request helpers/state.

This adds regression coverage that `CohereClientV2.generate()` routes through the v1 `/v1/generate` endpoint and sends the expected request body.

## Test Plan

- [x] `pnpm exec vitest src/test/client.test.ts --run`
- [x] `pnpm build`
- [x] `pnpm check src/ClientV2.ts src/test/client.test.ts`
- [x] `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Fixes runtime behavior for all legacy v1 methods on `CohereClientV2`; incorrect binding could have caused subtle failures in production SDK usage.
> 
> **Overview**
> **Fixes incorrect `this` binding** on `CohereClientV2` legacy v1 APIs (`generate`, `generateStream`, `classify`, `summarize`, `tokenize`, `detokenize`, `checkApiKey`). Those methods were bound to the internal `V2Client` instead of the v1 `CohereClient`, which could break calls that rely on v1 request helpers and routing.
> 
> Legacy calls now delegate to the v1 client with the correct binding so requests hit **v1 paths** (e.g. `/v1/generate`) as intended.
> 
> Adds a regression test that `CohereClientV2.generate()` targets `https://api.cohere.com/v1/generate` with the expected body. Minor cleanup: type-only `core` import and formatting in `ClientV2.ts` / existing tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd4ada08d03c859c3fcb3cd3cf90126e5df4e0dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->